### PR TITLE
wspr: use float32 for lat/lon values for grid calculation

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -4,4 +4,7 @@ go 1.25.3
 
 require tinygo.org/x/drivers v0.34.1-0.20260107195827-c21cd39813be
 
-require github.com/google/shlex v0.0.0-20191202100458-e7afc7fbc510 // indirect
+require (
+	github.com/chewxy/math32 v1.11.1 // indirect
+	github.com/google/shlex v0.0.0-20191202100458-e7afc7fbc510 // indirect
+)

--- a/go.sum
+++ b/go.sum
@@ -1,3 +1,5 @@
+github.com/chewxy/math32 v1.11.1 h1:b7PGHlp8KjylDoU8RrcEsRuGZhJuz8haxnKfuMMRqy8=
+github.com/chewxy/math32 v1.11.1/go.mod h1:dOB2rcuFrCn6UHrze36WSLVPKtzPMRAQvBvUwkSsLqs=
 github.com/google/shlex v0.0.0-20191202100458-e7afc7fbc510 h1:El6M4kTTCOh6aBiKaUGG7oYTSPP8MxqL4YI3kZKwcP4=
 github.com/google/shlex v0.0.0-20191202100458-e7afc7fbc510/go.mod h1:pupxD2MaaD3pAXIBCelhxNneeOaAeabZDe5s4K6zSpQ=
 tinygo.org/x/drivers v0.34.1-0.20260107195827-c21cd39813be h1:RfsgeMk+wQhaGjOqCNjIHBm/vNf+ayZhbJC/6cvNn1o=

--- a/wspr/maidenhead.go
+++ b/wspr/maidenhead.go
@@ -17,7 +17,7 @@
 package wspr
 
 import (
-	"math"
+	"github.com/chewxy/math32"
 )
 
 /*
@@ -25,7 +25,7 @@ This file contains support for forward and reverse encoding of lat-long pairs
 into the Maidenhead representation.
 */
 
-func Maidenhead(lat, long float64) string {
+func Maidenhead(lat, long float32) string {
 	lat += 90
 
 	long += 180
@@ -41,18 +41,18 @@ func Maidenhead(lat, long float64) string {
 	code[0] = 'A' + byte(int(long/20))
 	code[1] = 'A' + byte(int(lat/10))
 
-	long = math.Mod(long, 20)
-	lat = math.Mod(lat, 10)
+	long = math32.Mod(long, 20)
+	lat = math32.Mod(lat, 10)
 	code[2] = '0' + byte(int(long/2))
 	code[3] = '0' + byte(int(lat))
 
-	long = math.Mod(long, 2) * 24
-	lat = math.Mod(lat, 1) * 24
+	long = math32.Mod(long, 2) * 24
+	lat = math32.Mod(lat, 1) * 24
 	code[4] = 'A' + byte(int(long/2))
 	code[5] = 'A' + byte(int(lat))
 
-	long = math.Mod(long, 2) * 10
-	lat = math.Mod(lat, 1) * 10
+	long = math32.Mod(long, 2) * 10
+	lat = math32.Mod(lat, 1) * 10
 	code[6] = '0' + byte(int(long/2))
 	code[7] = '0' + byte(int(lat))
 

--- a/wspr/maidenhead_test.go
+++ b/wspr/maidenhead_test.go
@@ -21,8 +21,8 @@ import "testing"
 func TestMaidenhead(t *testing.T) {
 	tests := []struct {
 		name string
-		lat  float64
-		long float64
+		lat  float32
+		long float32
 		loc  string
 	}{
 		{"W1AW", 41.7148, -72.7272, "FN31PR"},


### PR DESCRIPTION
This PR modifies the `wspr` package to use `float32` insted of `float64` for lat/lon values for grid calculations.