### PR TITLE
wspr: add telemetry message using U4B/Traquito encoding

### DIFF
--- a/README.md
+++ b/README.md
@@ -90,6 +90,12 @@ Long Range Wide Area Networking (LoRaWAN)
 
 https://en.wikipedia.org/wiki/LoRa#LoRaWAN
 
+### U4B
+
+Telemetry protocol on Weak Signal Propagation Reporter (WSPR)
+
+https://qrp-labs.com/u4b/u4bdecoding.html
+
 ### WSPR
 
 Weak Signal Propagation Reporter (WSPR)

--- a/README.md
+++ b/README.md
@@ -17,13 +17,14 @@ func main() {
 	println("Starting WSPR communication example...")
 	time.Sleep(2 * time.Second)
 
+	// init the modem
 	println("WSPR modem initialized.")
 	radio := initRadio()
 
 	frequency := radio.GetBaseFrequency()
 	println("Transmitting on frequency", frequency, "Hz")
 
-	data := make([]byte, 162)
+	data := make([]byte, 256)
 
 	// Example WSPR packet data
 	// K1ABC FN42 37
@@ -38,18 +39,22 @@ func main() {
 		println("error writing WSPR message")
 		return
 	}
-	data = data[:n]
 
 	// transmit some data
-	for range 5 {
-		println("Transmitting WSPR message with", len(data), "symbols")
-		radio.WriteSymbols(data)
+	for range 50 {
+		println("Transmitting WSPR message with", n, "symbols")
+		if err := radio.WriteSymbols(data[:n]); err != nil {
+			println("error transmitting WSPR message:", err.Error())
+			return
+		}
 
-		time.Sleep(3 * time.Second)
+		println("Waiting for next transmission...")
+		time.Sleep(15 * time.Second)
 	}
 
 	time.Sleep(2 * time.Second)
 
+	// put the radio in standby
 	println("Putting radio in standby mode...")
 	radio.Standby()
 	time.Sleep(1 * time.Second)

--- a/examples/wspr/main.go
+++ b/examples/wspr/main.go
@@ -21,7 +21,7 @@ func main() {
 	frequency := radio.GetBaseFrequency()
 	println("Transmitting on frequency", frequency, "Hz")
 
-	data := make([]byte, 162)
+	data := make([]byte, 256)
 
 	// Example WSPR packet data
 	// K1ABC FN42 37

--- a/u4b/telemetry.go
+++ b/u4b/telemetry.go
@@ -1,0 +1,143 @@
+package u4b
+
+// The U4B telemetry message uses the U4B format,
+// a special encoding of the callsign and location
+// to carry telemetry data over WSPR.
+// For more information, see:
+// https://qrp-labs.com/u4b/u4bdecoding.html
+// https://traquito.github.io/pro/telemetry/
+
+import (
+	"errors"
+
+	"github.com/chewxy/math32"
+	"tinygo.org/x/wireless/wspr"
+)
+
+var (
+	ErrInvalidTelemetry = errors.New("invalid telemetry data")
+)
+
+// NewMessage encodes telemetry data using the U4B format
+// into a WSPR message.
+// The parameters are:
+// channel: 2-character channel identifier
+// grid: 2-character Maidenhead grid square
+// altitude: altitude in meters
+// temperature: temperature in degrees Celsius
+// voltage: voltage in millivolts
+// speed: speed in km/h
+func NewMessage(channel string, grid string, altitude int, temperature int, voltage int, speed int) (wspr.Message, error) {
+	callsign, err := encodeTelemetryCallSign(channel, grid, altitude)
+	if err != nil {
+		return 0, err
+	}
+
+	c, err := wspr.CallSign(callsign)
+	if err != nil {
+		return 0, err
+	}
+
+	g, p, err := encodeTelemetryGridPower(temperature, voltage, speed)
+	if err != nil {
+		return 0, err
+	}
+
+	l, err := wspr.Locator(g)
+	if err != nil {
+		return 0, err
+	}
+
+	return wspr.Message((c << 28) + (l << 13) + (wspr.Power(p) << 6)), nil
+}
+
+func encodeTelemetryCallSign(channel, grid string, altitude int) (string, error) {
+	if len(grid) != 2 || len(channel) != 2 {
+		return "", ErrInvalidTelemetry
+	}
+
+	grid5Val := grid[0] - 'A'
+	grid6Val := grid[1] - 'A'
+	alt := altitude / 20
+
+	val := uint32(grid5Val)
+	val = val*24 + uint32(grid6Val)
+	val = val*1068 + uint32(alt)
+
+	// extract
+	id6Val := val % 26
+	val = val / 26
+	id5Val := val % 26
+	val = val / 26
+	id4Val := val % 26
+	val = val / 26
+	id2Val := val % 36
+	val = val / 36
+
+	// convert to encoded form
+	id2 := encodeBase36(uint8(id2Val))
+	id4 := 'A' + byte(id4Val)
+	id5 := 'A' + byte(id5Val)
+	id6 := 'A' + byte(id6Val)
+
+	callsign := string([]byte{channel[0], id2, channel[1], id4, id5, id6})
+
+	return callsign, nil
+}
+
+func encodeBase36(val uint8) byte {
+	if val < 10 {
+		return '0' + val
+	}
+
+	return 'A' + (val - 10)
+}
+
+var powerDbmList = [19]uint8{
+	0, 3, 7,
+	10, 13, 17,
+	20, 23, 27,
+	30, 33, 37,
+	40, 43, 47,
+	50, 53, 57,
+	60,
+}
+
+func encodeTelemetryGridPower(temperature int, voltage int, speed int) (string, int, error) {
+	// convert inputs to encoded numbers
+	tempCNum := uint8(temperature + 50)
+	voltageNum := (uint8(math32.Round((float32(voltage)-300)/5)) + 20) % 40
+	speedKnotsNum := uint8(math32.Round(float32(speed) / 2.0))
+	gpsValidNum := uint8(1)
+
+	// convert inputs into a "big number"
+	val := uint32(0)
+	val = val*90 + uint32(tempCNum)
+	val = val*40 + uint32(voltageNum)
+	val = val*42 + uint32(speedKnotsNum)
+	val = val*2 + uint32(gpsValidNum)
+	val = val*2 + 1 // basic telemetry
+
+	// extract data from big number
+	powerVal := uint8(val % 19)
+	val = val / 19
+	g4Val := uint8(val % 10)
+	val = val / 10
+	g3Val := uint8(val % 10)
+	val = val / 10
+	g2Val := uint8(val % 18)
+	val = val / 18
+	g1Val := uint8(val % 18)
+	val = val / 18
+
+	// convert to encoded form
+	g1 := 'A' + g1Val
+	g2 := 'A' + g2Val
+	g3 := '0' + g3Val
+	g4 := '0' + g4Val
+
+	// store grid
+	grid := string([]byte{g1, g2, g3, g4})
+
+	return grid, int(powerDbmList[powerVal]), nil
+}

--- a/u4b/telemetry_test.go
+++ b/u4b/telemetry_test.go
@@ -1,0 +1,75 @@
+package u4b
+
+import (
+	"testing"
+)
+
+func TestEncodeBase36(t *testing.T) {
+	tests := []struct {
+		val      uint8
+		expected byte
+	}{
+		{0, '0'},
+		{9, '9'},
+		{10, 'A'},
+		{15, 'F'},
+		{35, 'Z'},
+	}
+	for _, tt := range tests {
+		got := encodeBase36(tt.val)
+		if got != tt.expected {
+			t.Errorf("encodeBase36(%d) = %c, want %c", tt.val, got, tt.expected)
+		}
+	}
+}
+
+func TestEncodeTelemetryCallSign(t *testing.T) {
+	callsign, err := encodeTelemetryCallSign("AB", "CD", 100)
+	if err != nil {
+		t.Errorf("unexpected error: %v", err)
+	}
+	if len(callsign) != 6 {
+		t.Errorf("callsign length = %d, want 6", len(callsign))
+	}
+
+	_, err = encodeTelemetryCallSign("A", "CD", 100)
+	if err == nil {
+		t.Error("expected error for short channel, got nil")
+	}
+	_, err = encodeTelemetryCallSign("AB", "C", 100)
+	if err == nil {
+		t.Error("expected error for short grid, got nil")
+	}
+}
+
+func TestEncodeTelemetryGridPower(t *testing.T) {
+	grid, power, err := encodeTelemetryGridPower(0, 500, 10)
+	if err != nil {
+		t.Errorf("unexpected error: %v", err)
+	}
+	if len(grid) != 4 {
+		t.Errorf("grid length = %d, want 4", len(grid))
+	}
+	if power < 0 || power > 60 {
+		t.Errorf("power = %d, out of expected range", power)
+	}
+}
+
+func TestNewTelemetryMessage(t *testing.T) {
+	msg, err := NewMessage("AB", "CD", 100, 0, 500, 10)
+	if err != nil {
+		t.Errorf("unexpected error: %v", err)
+	}
+	if msg == 0 {
+		t.Error("expected non-zero message")
+	}
+
+	_, err = NewMessage("A", "CD", 100, 0, 500, 10)
+	if err == nil {
+		t.Error("expected error for short channel, got nil")
+	}
+	_, err = NewMessage("AB", "C", 100, 0, 500, 10)
+	if err == nil {
+		t.Error("expected error for short grid, got nil")
+	}
+}


### PR DESCRIPTION
This PR adds a WSPR telemetry message using the U4B/Traquito encoding format.

See:
https://qrp-labs.com/u4b/u4bdecoding.html
https://traquito.github.io/pro/telemetry/